### PR TITLE
First version of stl generator

### DIFF
--- a/Software/Utils/generateSTLs.py
+++ b/Software/Utils/generateSTLs.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import os, sys
+FREECADPATH = '/usr/lib/freecad/lib/'
+sys.path.append(FREECADPATH)
+
+import FreeCAD, Mesh
+
+assembly_file = os.path.abspath(os.path.join('..', '..', 'src', 'SunriseAssembly.FCStd'))
+out_path = os.path.abspath('./stl')
+
+if __name__ == '__main__':
+
+    try:
+        os.stat(out_path)
+    except OSError:
+        os.mkdir(out_path)
+
+    FreeCAD.open(assembly_file)
+    doc = App.getDocument("SunriseAssembly")
+
+    printable = doc.getObjectsByLabel('Printable') + doc.getObjectsByLabel('Printable001')
+
+    for group in printable:
+        for obj in group.Group:
+            Mesh.export([obj] , os.path.join(out_path, obj.Label + '.stl'))
+
+    FreeCAD.closeDocument("SunriseAssembly")


### PR DESCRIPTION
I have just created a simple script to try to solve issue #26. 

When you run this from the Utils folder, it creates a stl folder containing all the stl files.

    user@pc ~/Sunrise/Software/Utils $ python generateSTLs.py

It can be modify to add subfolders, and take command line arguments if necessary (as I don't know what is the criteria for organizing the FCStd files, I did a very simple script)

:smile: 